### PR TITLE
Fixed wrong return value for ::write() method

### DIFF
--- a/LiquidCrystal_I2C.cpp
+++ b/LiquidCrystal_I2C.cpp
@@ -9,7 +9,7 @@
 #define printIIC(args)	Wire.write(args)
 inline size_t LiquidCrystal_I2C::write(uint8_t value) {
 	send(value, Rs);
-	return 0;
+	return 1;
 }
 
 #else

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=LiquidCrystal I2C
-version=1.1.1
+version=1.1.2
 author=Frank de Brabander
 maintainer=Marco Schwartz <marcolivier.schwartz@gmail.com>
 sentence=A library for I2C LCD displays.


### PR DESCRIPTION
The `write()` method must return the number of successfully written bytes (1 in this case).

Without this fix, if the latest AVR core is used, the library prints only the first character of a string as reported multiple time in this thread:
http://forum.arduino.cc/index.php?topic=357312.msg2463869#msg2463869
http://forum.arduino.cc/index.php?topic=357312.msg2468881#msg2468881
and here:
https://github.com/arduino/Arduino/issues/4142

Please consider also releasing an update of the library ASAP, I've already updated `library.properties` version to `1.1.2`.
