### PR TITLE
Support ATtiny MCUs by using TinyWireM instead of Wire

### DIFF
--- a/LiquidCrystal_I2C.cpp
+++ b/LiquidCrystal_I2C.cpp
@@ -14,15 +14,20 @@ inline size_t LiquidCrystal_I2C::write(uint8_t value) {
 
 #else
 #include "WProgram.h"
-
+ 
 #define printIIC(args)	Wire.send(args)
 inline void LiquidCrystal_I2C::write(uint8_t value) {
 	send(value, Rs);
 }
 
 #endif
-#include "Wire.h"
 
+#if defined (__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)
+#include <TinyWireM.h>
+#define Wire TinyWireM
+#else
+#include <Wire.h>
+#endif
 
 
 // When the display powers up, it is configured as follows:

--- a/LiquidCrystal_I2C.h
+++ b/LiquidCrystal_I2C.h
@@ -4,7 +4,13 @@
 
 #include <inttypes.h>
 #include "Print.h" 
+    
+#if defined (__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)
+#include <TinyWireM.h>
+#define Wire TinyWireM
+#else
 #include <Wire.h>
+#endif
 
 // commands
 #define LCD_CLEARDISPLAY 0x01


### PR DESCRIPTION
A simple patch to use TinyWireM on ATtiny85/45/25 MCUs, like those on the Digispark and many other boards.