### PR TITLE
Add platform espressif8266

### DIFF
--- a/library.json
+++ b/library.json
@@ -10,6 +10,7 @@
   "frameworks": "arduino",
   "platforms":
   [
-    "atmelavr"
+    "atmelavr",
+    "espressif8266"
   ]
 }


### PR DESCRIPTION
I tested this library with my Wemos D1 mini pro, which uses the espressif8266 platform and it works.